### PR TITLE
refactor(exports): improve exports 

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,6 @@
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
+import importPlugin from "eslint-plugin-import";
 
 export default [
   ...tseslint.config(
@@ -17,5 +18,13 @@ export default [
   },
   {
     ignores: ["dist", "node_modules", "public", ".cache"],
+  },
+  importPlugin.flatConfigs.recommended,
+  {
+    files: ["src/**"],
+    ignores: ["src/pages/**"],
+    rules: {
+      "import/no-default-export": "error",
+    },
   },
 ];

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "eslint": "^9.23.0",
     "eslint-config-prettier": "^10.1.1",
     "eslint-config-react-app": "^7.0.1",
+    "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-prettier": "^5.2.5",
     "gatsby-plugin-pnpm": "^1.2.10",
     "prettier": "^3.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       eslint-config-react-app:
         specifier: ^7.0.1
         version: 7.0.1(@babel/plugin-syntax-flow@7.26.0(@babel/core@7.26.10))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.10))(eslint@9.23.0)(typescript@5.8.2)
+      eslint-plugin-import:
+        specifier: ^2.31.0
+        version: 2.31.0(@typescript-eslint/parser@8.29.0(eslint@9.23.0)(typescript@5.8.2))(eslint@9.23.0)
       eslint-plugin-prettier:
         specifier: ^5.2.5
         version: 5.2.6(@types/eslint@9.6.1)(eslint-config-prettier@10.1.1(eslint@9.23.0))(eslint@9.23.0)(prettier@3.5.3)
@@ -10052,7 +10055,7 @@ snapshots:
     dependencies:
       eslint: 9.23.0
 
-  eslint-config-react-app@6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.8.2))(eslint@7.32.0)(typescript@5.8.2))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.8.2))(babel-eslint@10.1.0(eslint@9.23.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.8.2))(eslint@7.32.0))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@7.32.0))(eslint@7.32.0)(typescript@5.8.2):
+  eslint-config-react-app@6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.8.2))(eslint@7.32.0)(typescript@5.8.2))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.8.2))(babel-eslint@10.1.0(eslint@9.23.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.29.0(eslint@9.23.0)(typescript@5.8.2))(eslint@9.23.0))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@7.32.0))(eslint@7.32.0)(typescript@5.8.2):
     dependencies:
       '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.8.2))(eslint@7.32.0)(typescript@5.8.2)
       '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.8.2)
@@ -10102,6 +10105,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint@7.32.0):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.8.2)
+      eslint: 7.32.0
+      eslint-import-resolver-node: 0.3.9
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@9.23.0)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint@9.23.0):
     dependencies:
       debug: 3.2.7
@@ -10135,6 +10148,35 @@ snapshots:
       eslint: 9.23.0
       lodash: 4.17.21
       string-natural-compare: 3.0.1
+
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.8.2))(eslint@7.32.0):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.8
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 7.32.0
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint@7.32.0)
+      hasown: 2.0.2
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.8.2)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
 
   eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.23.0)(typescript@5.8.2))(eslint@9.23.0):
     dependencies:
@@ -11119,9 +11161,9 @@ snapshots:
       enhanced-resolve: 5.18.1
       error-stack-parser: 2.1.4
       eslint: 7.32.0
-      eslint-config-react-app: 6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.8.2))(eslint@7.32.0)(typescript@5.8.2))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.8.2))(babel-eslint@10.1.0(eslint@9.23.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.8.2))(eslint@7.32.0))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@7.32.0))(eslint@7.32.0)(typescript@5.8.2)
+      eslint-config-react-app: 6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.8.2))(eslint@7.32.0)(typescript@5.8.2))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.8.2))(babel-eslint@10.1.0(eslint@9.23.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.29.0(eslint@9.23.0)(typescript@5.8.2))(eslint@9.23.0))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@7.32.0))(eslint@7.32.0)(typescript@5.8.2)
       eslint-plugin-flowtype: 5.10.0(eslint@7.32.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.29.0(eslint@9.23.0)(typescript@5.8.2))(eslint@9.23.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.8.2))(eslint@7.32.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.23.0)
       eslint-plugin-react: 7.37.5(eslint@9.23.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@9.23.0)

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import ImageGallery from "../ImageGallery";
+import { ImageGallery } from "../ImageGallery";
 import { IGatsbyImageData } from "gatsby-plugin-image";
 import * as styles from "./Card.module.scss";
 
@@ -12,7 +12,12 @@ interface CardProps {
 
 console.log(styles);
 
-const Card: React.FC<CardProps> = ({ title, subtitle, content, images }) => {
+export const Card: React.FC<CardProps> = ({
+  title,
+  subtitle,
+  content,
+  images,
+}) => {
   return (
     <div className={styles.card}>
       <h1 className={styles.cardTitle}>{title}</h1>
@@ -29,5 +34,3 @@ const Card: React.FC<CardProps> = ({ title, subtitle, content, images }) => {
     </div>
   );
 };
-
-export default Card;

--- a/src/components/Card/index.ts
+++ b/src/components/Card/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./Card";
+export { Card } from "./Card";

--- a/src/components/ImageGallery/ImageGallery.tsx
+++ b/src/components/ImageGallery/ImageGallery.tsx
@@ -5,7 +5,7 @@ interface ImageData {
   images: IGatsbyImageData[];
 }
 
-const ImageGallery: React.FC<ImageData> = ({
+export const ImageGallery: React.FC<ImageData> = ({
   images,
 }: {
   images: ImageData[];
@@ -64,5 +64,3 @@ const ImageGallery: React.FC<ImageData> = ({
     </>
   );
 };
-
-export default ImageGallery;

--- a/src/components/ImageGallery/index.ts
+++ b/src/components/ImageGallery/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./ImageGallery";
+export { ImageGallery } from "./ImageGallery";

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,8 +1,6 @@
 import React, { ReactNode } from "react";
 import * as styles from "./Layout.module.scss";
 
-const Layout = ({ children }: ReactNode) => {
+export const Layout = ({ children }: ReactNode) => {
   return <main className={styles.container}>{children}</main>;
 };
-
-export default Layout;

--- a/src/components/Layout/index.ts
+++ b/src/components/Layout/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./Layout";
+export { Layout } from "./Layout";

--- a/src/components/Projects/Projects.tsx
+++ b/src/components/Projects/Projects.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { IGatsbyImageData } from "gatsby-plugin-image";
-import Card from "../Card";
+import { Card } from "../Card";
 import { useContent } from "../../hooks/useContent";
 import { useImages } from "../../hooks/useImages";
 
@@ -17,7 +17,7 @@ interface MarkdownRemarkNode {
   id: string;
 }
 
-const Projects: React.FC = () => {
+export const Projects: React.FC = () => {
   const content: MarkdownRemarkNode = useContent();
   const frontmatter: Frontmatter = content[0]?.frontmatter;
   const images: Record<string, IGatsbyImageData[]> = useImages(
@@ -38,5 +38,3 @@ const Projects: React.FC = () => {
     </div>
   );
 };
-
-export default Projects;

--- a/src/components/Projects/index.ts
+++ b/src/components/Projects/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./Projects";
+export { Projects } from "./Projects";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,4 @@
+export { Card } from "./Card";
+export { ImageGallery } from "./ImageGallery";
+export { Layout } from "./Layout";
+export { Projects } from "./Projects";

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import type { HeadFC, PageProps } from "gatsby";
-import Layout from "../components/Layout";
-import Projects from "../components/Projects";
+import { Layout, Projects } from "../components";
 
 const IndexPage: React.FC<PageProps> = () => {
   return (


### PR DESCRIPTION
Enforce named exports with an ESLint rule and use a barrel file to export all components for cleaner, safer and more robust imports.

Closes #3 